### PR TITLE
[#20] Use consistent name (backend suffix) for clojure code/service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - oraclejdk8
+
 sudo: required
 
 services:
@@ -14,7 +17,7 @@ script:
   - ./ci/build.sh
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "develop" ]; then
+  - if [[ "$TRAVIS_BRANCH" == "develop" -a "$TRAVIS_PULL_REQUEST" == "false"]]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
       docker push akvo/flow-api-backend;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - ./ci/build.sh
 
 after_success:
-  - if [[ "$TRAVIS_BRANCH" == "develop" -a "$TRAVIS_PULL_REQUEST" == "false"]]; then
+  - if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
       docker push akvo/flow-api-backend;
     fi

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,4 @@
-env FLOW_API_URL;
+env FLOW_API_BACKEND_URL;
 env TOKEN_INTROSPECTION_URL;
 env CLIENT_ID;
 env CLIENT_SECRET;
@@ -31,7 +31,7 @@ http {
         return 200;
       }
 
-      set_by_lua $upstream 'return os.getenv("FLOW_API_URL")';
+      set_by_lua $upstream 'return os.getenv("FLOW_API_BACKEND_URL")';
 
       access_by_lua '
           local introspection_url = os.getenv("TOKEN_INTROSPECTION_URL")
@@ -52,8 +52,7 @@ http {
             ngx.exit(ngx.HTTP_FORBIDDEN)
           end
 
-          ngx.req.set_header("X-AKVO-USER", res.email)
-          ngx.req.set_header("X-AKVO-CLAIMS", res)
+          ngx.req.set_header("X-Akvo-Email", res.email)
       ';
       rewrite ^/flow(/.*)$ $1 break;
       proxy_pass $upstream;


### PR DESCRIPTION
- Use a consistent name FLOW_API_BACKEND_URL
- Remove unused headers
- Use `X-Akvo-Email` for successfully authenticated users
  https://github.com/akvo/akvo-flow-api/blob/develop/api/src/clojure/org/akvo/flow_api/middleware/email.clj#L5