### PR TITLE
[#3] Reject invalid tokens by using the "active" key

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.11.2.2-alpine-fat
+FROM openresty/openresty:1.11.2.3-alpine-fat
 
 RUN apk add --no-cache build-base openssl-dev git
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -59,9 +59,10 @@ http {
 
           local res, err = require("resty.openidc").introspect(opts)
 
-          if err or not res then
+
+          if err or not res or not res.active then
             ngx.status = 403
-            ngx.say(err and err or "No access_token provided")
+            ngx.say(err and err or "access_token required")
             ngx.exit(ngx.HTTP_FORBIDDEN)
           end
 


### PR DESCRIPTION
- An instrospection call returns {"active": true} when the token is
  valid
- Update the latest published docker image