### PR TITLE
[#55] The wrap-json middleware already sets the proper headers

### DIFF
--- a/api/dev/resources/dev.edn
+++ b/api/dev/resources/dev.edn
@@ -8,7 +8,7 @@
  {:app
   {:middleware
    {:functions {:stacktrace #var ring.middleware.stacktrace/wrap-stacktrace}
-    :applied   ^:replace [:not-found :ring-defaults :wrap-email :json-body :wrap-anomaly :json-response :stacktrace]}}
+    :applied   ^:replace [:not-found :json-response :ring-defaults :wrap-email :json-body :wrap-anomaly :stacktrace]}}
   :http
   {:port 3000}
   :api-root "http://localhost:3000/"}}

--- a/api/resources/org/akvo/flow_api/system.edn
+++ b/api/resources/org/akvo/flow_api/system.edn
@@ -36,7 +36,7 @@
      :wrap-anomaly  #var org.akvo.flow-api.middleware.anomaly/wrap-anomaly
      :wrap-sentry   #var raven-clj.ring/wrap-sentry}
     :applied
-    [:not-found :ring-defaults :wrap-email :json-body :wrap-anomaly :json-response :wrap-sentry :hide-errors]
+    [:not-found :json-response :ring-defaults :wrap-email :json-body :wrap-anomaly :wrap-sentry :hide-errors]
     :arguments
     {:not-found   "Resource Not Found"
      :hide-errors "Internal Server Error"
@@ -44,7 +44,9 @@
      {:params    {:urlencoded true
                   :keywordize true}
       :responses {:not-modified-responses true
-                  :absolute-redirects     true}}
+                  :absolute-redirects     true
+                  :content-types          true
+                  :default-charset        "utf-8"}}
      :json-response {:key-fn #var org.akvo.flow-api.utils/kebab->camel}
      :wrap-sentry sentry-dsn}}}
   :http {:port http-port}

--- a/api/resources/org/akvo/flow_api/system.edn
+++ b/api/resources/org/akvo/flow_api/system.edn
@@ -44,9 +44,7 @@
      {:params    {:urlencoded true
                   :keywordize true}
       :responses {:not-modified-responses true
-                  :absolute-redirects     true
-                  :content-types          true
-                  :default-charset        "utf-8"}}
+                  :absolute-redirects     true}}
      :json-response {:key-fn #var org.akvo.flow-api.utils/kebab->camel}
      :wrap-sentry sentry-dsn}}}
   :http {:port http-port}


### PR DESCRIPTION
- The wrap-defaults seems to override the content-type and charset
  from wrap-json middleware