### PR TITLE
[#107] Change deploy cluster to "test" and set cpu limits

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -30,7 +30,7 @@ gcloud config set compute/zone europe-west1-d
 if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     gcloud container clusters get-credentials lumen
 else
-    gcloud container clusters get-credentials dev-cluster
+    gcloud container clusters get-credentials test
 fi
 
 # Deploying

--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -18,6 +18,11 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /secrets
+        resources:
+          requests:
+            cpu: "50m"
+          limits:
+            cpu: "1000m"
         env:
         - name: SECRETS_MOUNT_PATH
           value: "/secrets"
@@ -45,6 +50,11 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /secrets
+        resources:
+          requests:
+            cpu: "50m"
+          limits:
+            cpu: "1000m"
         env:
         - name: SECRETS_MOUNT_PATH
           value: "/secrets"


### PR DESCRIPTION
CPU request/limits are required in the new test cluster as the new k8s clusters are more busy than the previous versions