### PR TITLE
Configure livenessProbe (connect #134)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,4 +10,8 @@ WORKDIR /app
 
 COPY target/assembly/* /app/
 
-CMD ["java", "-cp", "./*", "org.akvo.flow_api.main"]
+CMD ["java", \
+     "-XX:+HeapDumpOnOutOfMemoryError", \
+     "-XX:HeapDumpPath=/dumps", \
+     "-cp", "./*", \
+     "org.akvo.flow_api.main"]

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ "${TRAVIS_BRANCH}" != "develop" ]] && [[ "${TRAVIS_BRANCH}" != "master" ]] && [[ "${TRAVIS_BRANCH}" != "issue/134-liveness" ]]; then
+if [[ "${TRAVIS_BRANCH}" != "develop" ]] && [[ "${TRAVIS_BRANCH}" != "master" ]]; then
     exit 0
 fi
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ "${TRAVIS_BRANCH}" != "develop" ]] && [[ "${TRAVIS_BRANCH}" != "master" ]]; then
+if [[ "${TRAVIS_BRANCH}" != "develop" ]] && [[ "${TRAVIS_BRANCH}" != "master" ]] && [[ "${TRAVIS_BRANCH}" != "issue/134-liveness" ]]; then
     exit 0
 fi
 

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -36,6 +36,17 @@ spec:
             configMapKeyRef:
               name: flow-api
               key: token.introspection.url
+      - name: flow-api-monitor
+        image: google/cloud-sdk:206.0.0-alpine
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          apk add --no-cache inotify-tools &&
+          gcloud auth activate-service-account --key-file=/secrets/jvm-debug.json &&
+          inotifywait -m /dumps -e close_write | while read path action file; do gsutil cp "$path$file" "gs://heap-dump/$file"; done;
+        volumeMounts:
+        - name: heap-dumps
+          mountPath: /dumps
       - name: flow-api-backend
         image: akvo/flow-api-backend:${TRAVIS_COMMIT}
         imagePullPolicy: Always
@@ -53,6 +64,8 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /secrets
+        - name: heap-dumps
+          mountPath: /dumps
         resources:
           requests:
             cpu: ${BACKEND_POD_CPU_REQUESTS}
@@ -74,3 +87,5 @@ spec:
       - name: secrets
         secret:
           secretName: flow-api-secrets
+      - name: heap-dumps
+        emptyDir: {}

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -19,6 +19,7 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /secrets
+          readOnly: true
         resources:
           requests:
             cpu: ${PROXY_POD_CPU_REQUESTS}
@@ -49,6 +50,7 @@ spec:
           mountPath: /dumps
         - name: secrets
           mountPath: /secrets
+          readOnly: true
       - name: flow-api-backend
         image: akvo/flow-api-backend:${TRAVIS_COMMIT}
         imagePullPolicy: Always

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -47,6 +47,8 @@ spec:
         volumeMounts:
         - name: heap-dumps
           mountPath: /dumps
+        - name: secrets
+          mountPath: /secrets
       - name: flow-api-backend
         image: akvo/flow-api-backend:${TRAVIS_COMMIT}
         imagePullPolicy: Always

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -65,6 +65,14 @@ spec:
           timeoutSeconds: 1
           successThreshold: 1
           failureThreshold: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 70
+          periodSeconds: 30
+          timeoutSeconds: 1
+          failureThreshold: 5
         volumeMounts:
         - name: secrets
           mountPath: /secrets


### PR DESCRIPTION
* Enable `livenessProbe` to check the container every 30s
* Configure a _sidecar_ container that watches a `/dumps` shared volume. We start the JVM with the option go generate a _heap dump_ when an `OutOfMemoryError` happens
* The sidecar container will pick the generated file and upload it to `gs://heap-dumps` 