### PR TITLE
[#139] Return HTTP 301 if X-Forwarded-Proto is http

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,10 @@ http {
     gzip_comp_level 9;
     gzip_types      application/json;
 
+    if ($http_x_forwarded_proto = "http") {
+      return 301 https://$host$request_uri;
+    }
+
     location /flow/config-refresh {
       set_by_lua $upstream 'return os.getenv("FLOW_API_BACKEND_URL")';
       rewrite ^/flow(/.*)$ $1 break;


### PR DESCRIPTION
TLS termination is done at GLB (Google Load Balancer) the only way to
know if the user is connecting via HTTPS or HTTP is by checking the
X-Forwarded-Proto HTTP header. When this header is 'http' we redirect
to use https.