### PR TITLE
[#136] Enable JVM heap allocation based on cgroups

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /app
 COPY target/assembly/* /app/
 
 CMD ["java", \
+     "-XX:+UnlockExperimentalVMOptions", \
+     "-XX:+UseCGroupMemoryLimitForHeap", \
      "-XX:+HeapDumpOnOutOfMemoryError", \
      "-XX:HeapDumpPath=/dumps", \
      "-cp", "./*", \


### PR DESCRIPTION
Inside Linux containers, recent versions of OpenJDK 8 can correctly
detect container-limited number of CPU cores by default. To enable the
detection of container-limited amount of RAM the following options can
be used:

    $ java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap ...

https://github.com/docker-library/docs/blob/b9c3b02663add9975a7cf7e390bb47ca54c3f8eb/openjdk/README.md#make-jvm-respect-cpu-and-ram-limits