### PR TITLE
[#134] Use the combination of hostname + timestamp for a heap dump

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,12 +10,6 @@ WORKDIR /app
 
 COPY target/assembly/* /app/
 
-CMD ["java", \
-     "-XshowSettings:vm", \
-     "-XX:+UnlockExperimentalVMOptions", \
-     "-XX:+UseCGroupMemoryLimitForHeap", \
-     "-XX:MaxRAMFraction=2", \
-     "-XX:+HeapDumpOnOutOfMemoryError", \
-     "-XX:HeapDumpPath=/dumps", \
-     "-cp", "./*", \
-     "org.akvo.flow_api.main"]
+COPY run.sh /app/run.sh
+
+CMD ["./run.sh"]

--- a/api/run.sh
+++ b/api/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -eu
+
+hostname=$(hostname)
+ts=$(date +%s)
+dump_filename="${hostname}-${ts}.hprof"
+
+java -XshowSettings:vm \
+     -XX:+UnlockExperimentalVMOptions \
+     -XX:+UseCGroupMemoryLimitForHeap \
+     -XX:MaxRAMFraction=2 \
+     -XX:+HeapDumpOnOutOfMemoryError \
+     -XX:HeapDumpPath="/dumps/${dump_filename}" \
+     -cp "./*" \
+     org.akvo.flow_api.main

--- a/ci/k8s/deployment.yaml.template
+++ b/ci/k8s/deployment.yaml.template
@@ -44,7 +44,7 @@ spec:
         - |
           apk add --no-cache inotify-tools &&
           gcloud auth activate-service-account --key-file=/secrets/jvm-debug.json &&
-          inotifywait -m /dumps -e close_write | while read path action file; do gsutil cp "$path$file" "gs://heap-dump/$file"; done;
+          inotifywait -m /dumps -e close_write | while read path action file; do gsutil cp "$path$file" "gs://heap-dump/$file"; rm -f "$path$file"; done;
         volumeMounts:
         - name: heap-dumps
           mountPath: /dumps


### PR DESCRIPTION
We can configure the JVM to generate a heap dump when an
OutOfMemoryError happens.  The parameter -XX:HeapDumpPath can be a
folder or a file.

When is a folder the JVM generates a java_pid<pid>.hprof file.
In the case of our services the java process running in a container we
always have the PID 1, which means that the path to the file is the
same.

The JVM will refuse to overwrite a file if this already exists,
e.g. Unable to create /dumps/java_pid1.hprof: File exists

By concatenating the container hostname and timestamp we generate
a unique filename for the heap dump.