### PR TITLE
[#136] Close PersistentManager after each http request

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
@@ -8,6 +8,7 @@
             [org.akvo.flow-api.endpoint.spec :as spec]
             [org.akvo.flow-api.endpoint.utils :as utils]
             [org.akvo.flow-api.middleware.resolve-alias :refer [wrap-resolve-alias]]
+            [org.akvo.flow-api.middleware.jdo-persistent-manager :as jdo-pm]
             [ring.util.response :refer [response]]))
 
 (defn next-page-url [api-root instance-id survey-id page-size cursor]
@@ -50,4 +51,5 @@
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]
   (-> (endpoint* deps)
-      (wrap-resolve-alias akvo-flow-server-config)))
+      (wrap-resolve-alias akvo-flow-server-config)
+      (jdo-pm/wrap-close-persistent-manager)))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
@@ -7,6 +7,7 @@
             [org.akvo.flow-api.endpoint.spec :as spec]
             [org.akvo.flow-api.endpoint.utils :as utils]
             [org.akvo.flow-api.middleware.resolve-alias :refer [wrap-resolve-alias]]
+            [org.akvo.flow-api.middleware.jdo-persistent-manager :as jdo-pm]
             [ring.util.response :refer [response]]))
 
 (defn add-links [folders api-root instance-id]
@@ -34,4 +35,5 @@
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]
   (-> (endpoint* deps)
-      (wrap-resolve-alias akvo-flow-server-config)))
+      (wrap-resolve-alias akvo-flow-server-config)
+      (jdo-pm/wrap-close-persistent-manager)))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -9,6 +9,7 @@
             [org.akvo.flow-api.endpoint.spec :as spec]
             [org.akvo.flow-api.endpoint.utils :as utils]
             [org.akvo.flow-api.middleware.resolve-alias :refer [wrap-resolve-alias]]
+            [org.akvo.flow-api.middleware.jdo-persistent-manager :as jdo-pm]
             [ring.util.response :refer [response]]))
 
 (defn find-form [forms form-id]
@@ -69,4 +70,5 @@
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]
   (-> (endpoint* deps)
-      (wrap-resolve-alias akvo-flow-server-config)))
+      (wrap-resolve-alias akvo-flow-server-config)
+      (jdo-pm/wrap-close-persistent-manager)))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
@@ -7,6 +7,7 @@
             [org.akvo.flow-api.endpoint.spec :as spec]
             [org.akvo.flow-api.endpoint.utils :as utils]
             [org.akvo.flow-api.middleware.resolve-alias :refer [wrap-resolve-alias]]
+            [org.akvo.flow-api.middleware.jdo-persistent-manager :as jdo-pm]
             [ring.util.response :refer [response]]))
 
 (defn add-survey-links [surveys api-root instance-id]
@@ -65,4 +66,5 @@
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]
   (-> (endpoint* deps)
-      (wrap-resolve-alias akvo-flow-server-config)))
+      (wrap-resolve-alias akvo-flow-server-config)
+      (jdo-pm/wrap-close-persistent-manager)))

--- a/api/src/clojure/org/akvo/flow_api/middleware/jdo_persistent_manager.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/jdo_persistent_manager.clj
@@ -1,5 +1,5 @@
 (ns org.akvo.flow-api.middleware.jdo-persistent-manager
-  (:import (com.gallatinsystems.framework.servlet PersistenceFilter)))
+  (:import [com.gallatinsystems.framework.servlet PersistenceFilter]))
 
 (defn wrap-close-persistent-manager [handler]
   (fn [request]

--- a/api/src/clojure/org/akvo/flow_api/middleware/jdo_persistent_manager.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/jdo_persistent_manager.clj
@@ -1,0 +1,11 @@
+(ns org.akvo.flow-api.middleware.jdo-persistent-manager
+  (:import (com.gallatinsystems.framework.servlet PersistenceFilter)))
+
+(defn wrap-close-persistent-manager [handler]
+  (fn [request]
+    (try
+      (handler request)
+      (finally
+        (let [jdo-persistence-manager (PersistenceFilter/getManager)]
+          (.flush jdo-persistence-manager)
+          (.close jdo-persistence-manager))))))


### PR DESCRIPTION
Heap dumps show that most of the memory is used by
com.google.appengine.datanucleus.query.JDOQLQuery$1, which seems like a
symptom of not closing the JDOQuery (as per http://www.datanucleus.org/products/accessplatform_3_1/jdo/troubleshooting.html).

The leak is caused by the Java classes imported from Flow as they access
a ThreadLocal PersistentManager from the PersistenceFilter (https://github.com/akvo/akvo-flow/blob/91485e66f757eb3c13dd528fdc8627c7637628b9/GAE/src/com/gallatinsystems/framework/servlet/PersistenceFilter.java#L54)

Note that this is not an issue in Flow as the PersistenceFilter takes care
of closing the PersistenceManager (https://github.com/akvo/akvo-flow/blob/91485e66f757eb3c13dd528fdc8627c7637628b9/GAE/src/com/gallatinsystems/framework/servlet/PersistenceFilter.java#L74), so resources are cleaned up.

This patch is basically the equivalent of the PersistenceFilter logic in Clojureland