### PR TITLE
Expect that sometimes the user does not exists in all instances

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/boundary/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/survey.clj
@@ -40,7 +40,7 @@
     (survey/keep-allowed-to-see
       surveys
       (mapping-fn (fn [instance]
-                    (let [user-id (user/id-by-email remote-api instance user-email)]
+                    (when-let [user-id (user/id-by-email remote-api instance user-email)]
                       (ds/with-remote-api remote-api instance
                         {:instance-id instance
                          :survey-ids (doall (survey/list-ids user-id))})))

--- a/api/src/clojure/org/akvo/flow_api/boundary/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/user.clj
@@ -3,7 +3,8 @@
             org.akvo.flow-api.component.cache
             org.akvo.flow-api.component.remote-api
             [org.akvo.flow-api.datastore :as ds]
-            [org.akvo.flow-api.datastore.user :as user]))
+            [org.akvo.flow-api.datastore.user :as user]
+            [org.akvo.flow-api.anomaly :as anomaly]))
 
 (defn get-id [{:keys [cache]} instance-id email]
   (cache/lookup @cache [instance-id email]))
@@ -18,3 +19,8 @@
       (let [id (user/id email)]
         (put-id user-cache instance-id email id)
         id))))
+
+(defn id-by-email-or-throw-error [remote-api instance-id email]
+  (or
+    (id-by-email remote-api instance-id email)
+    (anomaly/unauthorized "User does not exist" {:email email})))

--- a/api/src/clojure/org/akvo/flow_api/datastore/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/datastore/user.clj
@@ -1,13 +1,10 @@
 (ns org.akvo.flow-api.datastore.user
-  (:require [org.akvo.flow-api.anomaly :as anomaly]
-            [org.akvo.flow-api.datastore :as ds])
+  (:require [org.akvo.flow-api.datastore :as ds])
   (:import [com.gallatinsystems.user.dao UserDao]))
 
 (defn by-email [email]
-  (if-let [user (.findUserByEmail (UserDao.) email)]
-    user
-    (anomaly/unauthorized "User does not exist"
-                          {:email email})))
+  (.findUserByEmail (UserDao.) email))
 
 (defn id [email]
-  (ds/id (by-email email)))
+  (when-let [user (by-email email)]
+    (ds/id user)))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
@@ -41,7 +41,7 @@
                                                                :page_size :page-size}))
           page-size (when page-size
                       (Long/parseLong page-size))
-          user-id (user/id-by-email remote-api instance-id email)
+          user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)]
       (-> remote-api
           (data-point/list instance-id user-id survey {:page-size page-size

--- a/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
@@ -21,14 +21,14 @@
 
 (def params-spec (clojure.spec/keys :opt-un [::spec/parent-id]))
 
-(defn endpoint* [{:keys [remote-api akvo-flow-server-config api-root]}]
+(defn endpoint* [{:keys [remote-api api-root]}]
   (GET "/folders" {:keys [email instance-id alias params]}
     (let [{:keys [parent-id]} (spec/validate-params params-spec
                                                     (rename-keys params
                                                                  {:parent_id :parent-id}))]
       (-> remote-api
           (folder/list instance-id
-                       (user/id-by-email remote-api instance-id email)
+                       (user/id-by-email-or-throw-error remote-api instance-id email)
                        (or parent-id "0"))
           (add-links api-root alias)
           (folders-response)))))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :refer [rename-keys]]
             [clojure.spec]
             [compojure.core :refer :all]
-            [org.akvo.flow-api.anomaly :as anomaly]
             [org.akvo.flow-api.boundary.form-instance :as form-instance]
             [org.akvo.flow-api.boundary.survey :as survey]
             [org.akvo.flow-api.boundary.user :as user]
@@ -55,7 +54,7 @@
                                                                :page_size :page-size}))
           page-size (when page-size
                       (Long/parseLong page-size))
-          user-id (user/id-by-email remote-api instance-id email)
+          user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)
           form (find-form (:forms survey) form-id)]
       (if (some? form)

--- a/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
@@ -48,7 +48,7 @@
                                                      params)]
        (-> remote-api
            (survey/by-id instance-id
-                         (user/id-by-email remote-api instance-id email)
+                         (user/id-by-email-or-throw-error remote-api instance-id email)
                          survey-id)
            (add-form-instances-links api-root alias)
            (add-data-points-link api-root alias)
@@ -59,7 +59,7 @@
                                                                   {:folder_id :folder-id}))]
        (-> remote-api
            (survey/list-by-folder instance-id
-                        (user/id-by-email remote-api instance-id email)
+                        (user/id-by-email-or-throw-error remote-api instance-id email)
                         folder-id)
            (add-survey-links api-root alias)
            (surveys-response))))))

--- a/api/test/clojure/org/akvo/flow_api/datastore/survey_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/datastore/survey_test.clj
@@ -65,6 +65,7 @@
                                                                                :survey-ids ["2"]}))))
   (testing "Zero permissions"
     (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [])))
+    (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [nil])))
     (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [{:instance-id "a"
                                                                                 :survey-ids []}]))))
   (testing "Same survey id, but different instance"

--- a/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
@@ -15,8 +15,7 @@
 (deftest user-tests
   (ds/with-remote-api (:remote-api fixtures/*system*) "akvoflowsanbox"
     (testing "Non existing user"
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (user/id "no-such@user.com"))))
+      (is (nil? (user/id "no-such@user.com"))))
 
     (testing "Existing users"
       (are [email] (number? (user/id email))


### PR DESCRIPTION
The default behaviour for when a user doesnt exist in an instance was
to throw a 403 exception, which in the case of the /check_perms sometimes
it ended in a 500 if survey/filter-surveys was done using pmap.

Changing the behaviour in the case of survey/filter-surveys so that we
expect that sometimes the user will not exists in some instances and hence
he will will not allows to see anything in that instance

Fixes #151