### PR TITLE
Cache unknown users

### DIFF
--- a/api/resources/org/akvo/flow_api/system.edn
+++ b/api/resources/org/akvo/flow_api/system.edn
@@ -4,6 +4,7 @@
   :remote-api #var org.akvo.flow-api.component.remote-api/remote-api
   :akvo-flow-server-config #var org.akvo.flow-api.component.akvo-flow-server-config/akvo-flow-server-config
   :user-cache #var org.akvo.flow-api.component.cache/ttl-memory-cache
+  :unknown-user-cache #var org.akvo.flow-api.component.cache/ttl-memory-cache
   :survey-cache #var org.akvo.flow-api.component.cache/ttl-memory-cache}
  :endpoints
  {:root #var org.akvo.flow-api.endpoint.root/endpoint
@@ -16,10 +17,11 @@
  :dependencies
  {:http [:app]
   :app  [:root :folder :survey :data-point :form-instance :config-refresh :flumenfly]
-  :remote-api [:akvo-flow-server-config :user-cache :survey-cache]
+  :remote-api [:akvo-flow-server-config :user-cache :survey-cache :unknown-user-cache]
   :akvo-flow-server-config []
   :root []
   :user-cache []
+  :unknown-user-cache []
   :survey-cache []
   :folder [:remote-api :akvo-flow-server-config :api-root]
   :flumenfly [:remote-api :akvo-flow-server-config]
@@ -58,5 +60,6 @@
   :akvo-flow-server-config {:github-auth-token github-auth-token
                             :tmp-dir tmp-dir}
   :user-cache {:ttl 86400000} ;; 1 day
+  :unknown-user-cache {:ttl 600000} ;; 10 mins
   :survey-cache {:ttl 3600000} ;; 1 hr
   :api-root api-root}}

--- a/api/src/clojure/org/akvo/flow_api/boundary/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/survey.clj
@@ -40,7 +40,7 @@
     (survey/keep-allowed-to-see
       surveys
       (mapping-fn (fn [instance]
-                    (let [user-id (user/id-by-email remote-api instance user-email)]
+                    (when-let [user-id (user/id-by-email remote-api instance user-email)]
                       (ds/with-remote-api remote-api instance
                         {:instance-id instance
                          :survey-ids (doall (survey/list-ids user-id))})))

--- a/api/src/clojure/org/akvo/flow_api/boundary/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/user.clj
@@ -16,8 +16,8 @@
   (cache/has? @cache [instance-id email]))
 
 (defn id-by-email [{:keys [user-cache unknown-user-cache] :as this} instance-id email]
-  (if-let [id (get-id user-cache instance-id email)]
-    id
+  (or
+    (get-id user-cache instance-id email)
     (when-not (has? unknown-user-cache instance-id email)
       (ds/with-remote-api this instance-id
         (let [id (user/id email)

--- a/api/src/clojure/org/akvo/flow_api/boundary/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/user.clj
@@ -12,16 +12,17 @@
 (defn put-id [{:keys [cache]} instance-id email id]
   (swap! cache cache/miss [instance-id email] id))
 
+(defn has? [{:keys [cache]} instance-id email]
+  (cache/has? @cache [instance-id email]))
+
 (defn id-by-email [{:keys [user-cache unknown-user-cache] :as this} instance-id email]
   (if-let [id (get-id user-cache instance-id email)]
     id
-    (if (cache/has? @(:cache unknown-user-cache) [instance-id email])
-      nil
+    (when-not (has? unknown-user-cache instance-id email)
       (ds/with-remote-api this instance-id
-        (let [id (user/id email)]
-          (if id
-            (put-id user-cache instance-id email id)
-            (put-id unknown-user-cache instance-id email id))
+        (let [id (user/id email)
+              which-cache (if id user-cache unknown-user-cache)]
+          (put-id which-cache instance-id email id)
           id)))))
 
 (defn id-by-email-or-throw-error [remote-api instance-id email]

--- a/api/src/clojure/org/akvo/flow_api/boundary/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/boundary/user.clj
@@ -3,7 +3,8 @@
             org.akvo.flow-api.component.cache
             org.akvo.flow-api.component.remote-api
             [org.akvo.flow-api.datastore :as ds]
-            [org.akvo.flow-api.datastore.user :as user]))
+            [org.akvo.flow-api.datastore.user :as user]
+            [org.akvo.flow-api.anomaly :as anomaly]))
 
 (defn get-id [{:keys [cache]} instance-id email]
   (cache/lookup @cache [instance-id email]))
@@ -18,3 +19,8 @@
       (let [id (user/id email)]
         (put-id user-cache instance-id email id)
         id))))
+
+(defn id-by-email-or-throw-error [remote-api instance-id email]
+  (or
+    (id-by-email remote-api instance-id email)
+    (anomaly/unauthorized "User does not exist" {:email email})))

--- a/api/src/clojure/org/akvo/flow_api/datastore/user.clj
+++ b/api/src/clojure/org/akvo/flow_api/datastore/user.clj
@@ -1,13 +1,10 @@
 (ns org.akvo.flow-api.datastore.user
-  (:require [org.akvo.flow-api.anomaly :as anomaly]
-            [org.akvo.flow-api.datastore :as ds])
+  (:require [org.akvo.flow-api.datastore :as ds])
   (:import [com.gallatinsystems.user.dao UserDao]))
 
 (defn by-email [email]
-  (if-let [user (.findUserByEmail (UserDao.) email)]
-    user
-    (anomaly/unauthorized "User does not exist"
-                          {:email email})))
+  (.findUserByEmail (UserDao.) email))
 
 (defn id [email]
-  (ds/id (by-email email)))
+  (when-let [user (by-email email)]
+    (ds/id user)))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
@@ -41,7 +41,7 @@
                                                                :page_size :page-size}))
           page-size (when page-size
                       (Long/parseLong page-size))
-          user-id (user/id-by-email remote-api instance-id email)
+          user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)]
       (-> remote-api
           (data-point/list instance-id user-id survey {:page-size page-size

--- a/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
@@ -21,14 +21,14 @@
 
 (def params-spec (clojure.spec/keys :opt-un [::spec/parent-id]))
 
-(defn endpoint* [{:keys [remote-api akvo-flow-server-config api-root]}]
+(defn endpoint* [{:keys [remote-api api-root]}]
   (GET "/folders" {:keys [email instance-id alias params]}
     (let [{:keys [parent-id]} (spec/validate-params params-spec
                                                     (rename-keys params
                                                                  {:parent_id :parent-id}))]
       (-> remote-api
           (folder/list instance-id
-                       (user/id-by-email remote-api instance-id email)
+                       (user/id-by-email-or-throw-error remote-api instance-id email)
                        (or parent-id "0"))
           (add-links api-root alias)
           (folders-response)))))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :refer [rename-keys]]
             [clojure.spec]
             [compojure.core :refer :all]
-            [org.akvo.flow-api.anomaly :as anomaly]
             [org.akvo.flow-api.boundary.form-instance :as form-instance]
             [org.akvo.flow-api.boundary.survey :as survey]
             [org.akvo.flow-api.boundary.user :as user]
@@ -55,7 +54,7 @@
                                                                :page_size :page-size}))
           page-size (when page-size
                       (Long/parseLong page-size))
-          user-id (user/id-by-email remote-api instance-id email)
+          user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)
           form (find-form (:forms survey) form-id)]
       (if (some? form)

--- a/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
@@ -48,7 +48,7 @@
                                                      params)]
        (-> remote-api
            (survey/by-id instance-id
-                         (user/id-by-email remote-api instance-id email)
+                         (user/id-by-email-or-throw-error remote-api instance-id email)
                          survey-id)
            (add-form-instances-links api-root alias)
            (add-data-points-link api-root alias)
@@ -59,7 +59,7 @@
                                                                   {:folder_id :folder-id}))]
        (-> remote-api
            (survey/list-by-folder instance-id
-                        (user/id-by-email remote-api instance-id email)
+                        (user/id-by-email-or-throw-error remote-api instance-id email)
                         folder-id)
            (add-survey-links api-root alias)
            (surveys-response))))))

--- a/api/test/clojure/org/akvo/flow_api/datastore/survey_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/datastore/survey_test.clj
@@ -65,6 +65,7 @@
                                                                                :survey-ids ["2"]}))))
   (testing "Zero permissions"
     (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [])))
+    (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [nil])))
     (is (= [] (survey/keep-allowed-to-see [{:instance-id "a" :survey-id "1"}] [{:instance-id "a"
                                                                                 :survey-ids []}]))))
   (testing "Same survey id, but different instance"

--- a/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
@@ -15,8 +15,7 @@
 (deftest user-tests
   (ds/with-remote-api (:remote-api fixtures/*system*) "akvoflowsanbox"
     (testing "Non existing user"
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (user/id "no-such@user.com"))))
+      (is (nil? (user/id "no-such@user.com"))))
 
     (testing "Existing users"
       (are [email] (number? (user/id email))

--- a/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/datastore/user_test.clj
@@ -2,13 +2,23 @@
   (:require  [clojure.test :refer :all]
              [org.akvo.flow-api.datastore :as ds]
              [org.akvo.flow-api.datastore.user :as user]
-             [org.akvo.flow-api.fixtures :as fixtures]))
+             [org.akvo.flow-api.fixtures :as fixtures]
+             [org.akvo.flow-api.boundary.user :as user-cache]
+             [akvo.commons.gae :as gae]
+             [akvo.commons.gae.query :as query]))
+
+(defn uuid [] (str (java.util.UUID/randomUUID)))
+(def local-ds {:hostname "localhost" :port 8888})
 
 (def system {:components
-             {:remote-api #'org.akvo.flow-api.component.remote-api/local-api}
-             :dependencies {:remote-api []}
+             {:remote-api #'org.akvo.flow-api.component.remote-api/local-api
+              :user-cache #'org.akvo.flow-api.component.cache/ttl-memory-cache
+              :unknown-user-cache #'org.akvo.flow-api.component.cache/ttl-memory-cache}
+             :dependencies {:remote-api []
+                            :user-cache []}
              :endpoints {}
-             :config {}})
+             :config {:user-cache {:ttl 86400000}
+                      :unknown-user-cache {:ttl 600000}}})
 
 (use-fixtures :once (fixtures/system system))
 
@@ -22,3 +32,41 @@
         "akvo.flow.user.test@gmail.com"
         "akvo.flow.user.test2@gmail.com"
         "akvo.flow.user.test3@gmail.com"))))
+
+(defn find-user [unique-email]
+  (gae/with-datastore [ds unique-email]
+    (first (iterator-seq (.iterator (akvo.commons.gae.query/result ds
+                                      {:kind "User"
+                                       :filter (query/= "emailAddress" unique-email)}))))))
+
+(defn create-user [unique-email]
+  (gae/with-datastore [ds unique-email]
+    (gae/put! ds "User" {"emailAddress" unique-email}))
+
+  (fixtures/try-for "GAE took too long to return results" 10
+    (find-user unique-email)))
+
+(defn delete-user [unique-email]
+  (let [user (find-user unique-email)]
+    (gae/with-datastore [ds local-ds]
+      (.delete ds (into-array [(.getKey user)]))))
+
+  (fixtures/try-for "GAE took too long to return results" 10
+    (not (find-user unique-email))))
+
+(deftest user-cache
+  (let [remote-api (assoc (:remote-api fixtures/*system*)
+                     :user-cache (:user-cache fixtures/*system*)
+                     :unknown-user-cache (:unknown-user-cache fixtures/*system*))]
+    (testing "User is cached"
+      (let [unique-email (uuid)]
+        (create-user unique-email)
+        (is (some? (user-cache/id-by-email remote-api "akvoflowsanbox" unique-email)))
+        (delete-user unique-email)
+        (is (some? (user-cache/id-by-email remote-api "akvoflowsanbox" unique-email)))))
+
+    (testing "Cache also if the user does not exist"
+      (let [unique-email (uuid)]
+        (is (nil? (user-cache/id-by-email remote-api "akvoflowsanbox" unique-email)))
+        (create-user unique-email)
+        (is (nil? (user-cache/id-by-email remote-api "akvoflowsanbox" unique-email)))))))


### PR DESCRIPTION
Using a different cache than the regular users, so that we can use a
shorter TTL.

We want to use a shorter TTL (10 min vs 1 day) because while the regular user cannot change its email -> GAE id mapping, it is possible that a user is added to an instance so we want to pick up this change within a reasonable time frame

Fixes #154