### PR TITLE
Include auth0 client-id as possible audience value

### DIFF
--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -154,7 +154,7 @@ http {
          local function check_audience(val)
             if type(val) == "table" then
                 for _, aud in pairs(val) do
-                    if aud == "http://akvo.org" then return true end
+                    if aud == "http://akvo.org" or aud=="D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK" then return true end
                 end
                 return false
             else


### PR DESCRIPTION
As https://tools.ietf.org/html/rfc7519#section-4.1.3 states on `aud` value 

This change just keep using the aud value as we did before, so:

> Each principal intended to process the JWT MUST identify itself with a value in the audience claim.  If the principal processing the claim does not identify itself with a value in the "aud" claim when this claim is present, then the JWT MUST be rejected.

And we only add other application specific value

> The interpretation of audience values is generally application specific. Use of this claim is OPTIONAL.

Thus we only have 2 possible values, the change uses a simple `OR` logical condition

