### PR TITLE
Avoid validating aud jwt value with auth0

### DIFF
--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -151,25 +151,13 @@ http {
             expiry_claim = "exp"
          }
 
-         local function check_audience(val)
-            if type(val) == "table" then
-                for _, aud in pairs(val) do
-                    if aud == "http://akvo.org" then return true end
-                end
-                return false
-            else
-                return val == "http://akvo.org"
-            end
-         end
-
          local validators = require "resty.jwt-validators"
          validators.set_system_leeway(120)
          local res, err, access_token = openidc.bearer_jwt_verify(opts,
             {
               exp = validators.is_not_expired(),
               nbf = validators.opt_is_not_before(),
-              iss = validators.equals(os.getenv("OIDC_EXPECTED_ISSUER")),
-              aud = check_audience
+              iss = validators.equals(os.getenv("OIDC_EXPECTED_ISSUER"))
             })
 
          if err or not res then


### PR DESCRIPTION
[After agreeing that we don't want to accumulate a list of audiences in flow-api](https://github.com/akvo/akvo-flow-api/pull/169), we choose to ignore this value now