### PR TITLE
Add logs

### DIFF
--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -171,6 +171,8 @@ http {
             end
             ngx.exit(ngx.HTTP_FORBIDDEN)
          end
+          
+          ngx.log(ngx.WARN, "bearer_jwt_verify response: ", res)
 
           local v = cache_get("userinfo", access_token)
 


### PR DESCRIPTION
Auth0 is rejecting the call_userinfo_endpoint() call

Debugging here if we can take the email directly from the bearer_jwt_verify response so we can avoid the userinfo call 