### PR TITLE
Read api-root from req payload

### DIFF
--- a/api/resources/org/akvo/flow_api/system.edn
+++ b/api/resources/org/akvo/flow_api/system.edn
@@ -25,11 +25,11 @@
   :unknown-user-cache []
   :survey-list-cache []
   :survey-cache []
-  :folder [:remote-api :akvo-flow-server-config :api-root]
+  :folder [:remote-api :akvo-flow-server-config]
   :flumenfly [:remote-api :akvo-flow-server-config]
-  :survey [:remote-api :akvo-flow-server-config :api-root]
-  :data-point [:remote-api :akvo-flow-server-config :api-root]
-  :form-instance [:remote-api :akvo-flow-server-config :api-root]
+  :survey [:remote-api :akvo-flow-server-config]
+  :data-point [:remote-api :akvo-flow-server-config]
+  :form-instance [:remote-api :akvo-flow-server-config]
   :config-refresh [:akvo-flow-server-config]}
  :config
  {:app
@@ -66,4 +66,4 @@
   :unknown-user-cache {:ttl 600000} ;; 10 mins
   :survey-list-cache {:ttl 300000} ;; 5 mins
   :survey-cache {:ttl 3600000} ;; 1 hr
-  :api-root api-root}}
+  }}

--- a/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
@@ -31,7 +31,7 @@
 (def params-spec (clojure.spec/keys :req-un [::spec/survey-id]
                                     :opt-un [::spec/page-size ::spec/cursor]))
 
-(defn endpoint* [{:keys [remote-api api-root]}]
+(defn endpoint* [{:keys [remote-api]}]
   (GET "/data_points" {:keys [email instance-id alias params] :as req}
     (let [{:keys [survey-id
                   page-size

--- a/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/data_point.clj
@@ -32,7 +32,7 @@
                                     :opt-un [::spec/page-size ::spec/cursor]))
 
 (defn endpoint* [{:keys [remote-api api-root]}]
-  (GET "/data_points" {:keys [email instance-id alias params]}
+  (GET "/data_points" {:keys [email instance-id alias params] :as req}
     (let [{:keys [survey-id
                   page-size
                   cursor]} (spec/validate-params params-spec
@@ -46,7 +46,7 @@
       (-> remote-api
           (data-point/list instance-id user-id survey {:page-size page-size
                                                        :cursor cursor})
-          (add-next-page-url api-root alias survey-id page-size)
+          (add-next-page-url (utils/get-api-root req) alias survey-id page-size)
           (response)))))
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]

--- a/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
@@ -22,7 +22,7 @@
 (def params-spec (clojure.spec/keys :opt-un [::spec/parent-id]))
 
 (defn endpoint* [{:keys [remote-api api-root]}]
-  (GET "/folders" {:keys [email instance-id alias params]}
+  (GET "/folders" {:keys [email instance-id alias params] :as req}
     (let [{:keys [parent-id]} (spec/validate-params params-spec
                                                     (rename-keys params
                                                                  {:parent_id :parent-id}))]
@@ -30,7 +30,7 @@
           (folder/list instance-id
                        (user/id-by-email-or-throw-error remote-api instance-id email)
                        (or parent-id "0"))
-          (add-links api-root alias)
+          (add-links (utils/get-api-root req) alias)
           (folders-response)))))
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]

--- a/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/folder.clj
@@ -21,7 +21,7 @@
 
 (def params-spec (clojure.spec/keys :opt-un [::spec/parent-id]))
 
-(defn endpoint* [{:keys [remote-api api-root]}]
+(defn endpoint* [{:keys [remote-api]}]
   (GET "/folders" {:keys [email instance-id alias params] :as req}
     (let [{:keys [parent-id]} (spec/validate-params params-spec
                                                     (rename-keys params

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -43,7 +43,7 @@
                                     :opt-un [::spec/cursor ::spec/page-size]))
 
 (defn endpoint* [{:keys [remote-api api-root]}]
-  (GET "/form_instances" {:keys [email instance-id alias params]}
+  (GET "/form_instances" {:keys [email instance-id alias params] :as req}
     (let [{:keys [survey-id
                   form-id
                   page-size
@@ -61,7 +61,7 @@
         (-> remote-api
             (form-instance/list instance-id user-id form {:page-size page-size
                                                           :cursor cursor})
-            (add-next-page-url api-root alias survey-id form-id page-size)
+            (add-next-page-url (utils/get-api-root req) alias survey-id form-id page-size)
             (response))
         {:status 404
          :body {"formId" form-id

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -42,7 +42,7 @@
 (def params-spec (clojure.spec/keys :req-un [::spec/survey-id ::spec/form-id]
                                     :opt-un [::spec/cursor ::spec/page-size]))
 
-(defn endpoint* [{:keys [remote-api api-root]}]
+(defn endpoint* [{:keys [remote-api]}]
   (GET "/form_instances" {:keys [email instance-id alias params] :as req}
     (let [{:keys [survey-id
                   form-id

--- a/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
@@ -41,7 +41,7 @@
 
 (def survey-list-params-spec (clojure.spec/keys :req-un [::spec/folder-id]))
 
-(defn endpoint* [{:keys [remote-api api-root]}]
+(defn endpoint* [{:keys [remote-api]}]
   (routes
    (GET "/surveys/:survey-id" {:keys [email alias instance-id params] :as req}
      (let [{:keys [survey-id]} (spec/validate-params survey-definition-params-spec
@@ -51,7 +51,7 @@
                          (user/id-by-email-or-throw-error remote-api instance-id email)
                          survey-id)
            (add-form-instances-links (utils/get-api-root req) alias)
-           (add-data-points-link api-root alias)
+           (add-data-points-link (utils/get-api-root req) alias)
            (response))))
    (GET "/surveys" {:keys [email alias instance-id params] :as req}
      (let [{:keys [folder-id]} (spec/validate-params survey-list-params-spec

--- a/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/survey.clj
@@ -43,17 +43,17 @@
 
 (defn endpoint* [{:keys [remote-api api-root]}]
   (routes
-   (GET "/surveys/:survey-id" {:keys [email alias instance-id params]}
+   (GET "/surveys/:survey-id" {:keys [email alias instance-id params] :as req}
      (let [{:keys [survey-id]} (spec/validate-params survey-definition-params-spec
                                                      params)]
        (-> remote-api
            (survey/by-id instance-id
                          (user/id-by-email-or-throw-error remote-api instance-id email)
                          survey-id)
-           (add-form-instances-links api-root alias)
+           (add-form-instances-links (utils/get-api-root req) alias)
            (add-data-points-link api-root alias)
            (response))))
-   (GET "/surveys" {:keys [email alias instance-id params]}
+   (GET "/surveys" {:keys [email alias instance-id params] :as req}
      (let [{:keys [folder-id]} (spec/validate-params survey-list-params-spec
                                                      (rename-keys params
                                                                   {:folder_id :folder-id}))]
@@ -61,7 +61,7 @@
            (survey/list-by-folder instance-id
                         (user/id-by-email-or-throw-error remote-api instance-id email)
                         folder-id)
-           (add-survey-links api-root alias)
+           (add-survey-links (utils/get-api-root req) alias)
            (surveys-response))))))
 
 (defn endpoint [{:keys [akvo-flow-server-config] :as deps}]

--- a/api/src/clojure/org/akvo/flow_api/endpoint/utils.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/utils.clj
@@ -12,6 +12,11 @@
                  (url-encode v)))
        (s/join "&")))
 
+(defn get-api-root [request]
+  (let [scheme (name (:scheme request))
+        hostname (get (:headers request) "host")]
+    (str scheme "://" hostname "/")))
+
 (defn url-builder
   ([api-root instance path]
    (url-builder api-root instance path nil))

--- a/api/src/clojure/org/akvo/flow_api/main.clj
+++ b/api/src/clojure/org/akvo/flow_api/main.clj
@@ -22,7 +22,6 @@
 (defn -main [& args]
   (let [bindings {'http-port (Integer/parseInt (:http-port env "3000"))
                   'github-auth-token (secret-value "github-auth-token")
-                  'api-root (utils/ensure-trailing-slash (:api-root env))
                   'sentry-dsn (secret-value "sentry-dsn")
                   'tmp-dir (utils/ensure-trailing-slash (System/getProperty "java.io.tmpdir"))}
         system   (->> (load-system [(io/resource "org/akvo/flow_api/system.edn")] bindings)


### PR DESCRIPTION
When lumen tryes to import a flow survey based the search in urls inside flow-api response, these urls needs to adapt to current proxy, auth0 or keycloak ones, so the value of the api-root has to be taken from request value 

Relates #176 