### PR TITLE
[#192] Filter form instances by submission date

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -9,7 +9,8 @@
             [org.akvo.flow-api.endpoint.utils :as utils]
             [org.akvo.flow-api.middleware.resolve-alias :refer [wrap-resolve-alias]]
             [org.akvo.flow-api.middleware.jdo-persistent-manager :as jdo-pm]
-            [ring.util.response :refer [response]]))
+            [ring.util.response :refer [response]])
+  (:import java.time.Instant))
 
 (defn find-form [forms form-id]
   (some #(if (= (:id %) form-id)
@@ -39,28 +40,57 @@
                               (:cursor form-instances)))
         (dissoc :cursor))))
 
+(defn parse-date
+  [^String s]
+  (if (.contains s "T")
+    (try
+      (Instant/parse s)
+      (catch Exception _))
+    (try
+      (Instant/ofEpochSecond (Long/parseLong s))
+      (catch Exception _))))
+
+(defn parse-filter
+  [^String s]
+  (let [[_ op ts] (first (re-seq #"^(>=|>|<=|<)(\S+)$" s))]
+    {:operator op
+     :timestamp (parse-date ts)}))
+
+(defn valid-filter?
+  [^String s]
+  (let [parsed (parse-filter s)]
+    (boolean (and (:operator parsed) (:timestamp parsed)))))
+
+(s/def ::submission-date valid-filter?)
+
 (def params-spec (s/keys :req-un [::spec/survey-id ::spec/form-id]
-                         :opt-un [::spec/cursor ::spec/page-size]))
+                         :opt-un [::spec/cursor ::spec/page-size
+                                  ::submission-date]))
 
 (defn endpoint* [{:keys [remote-api]}]
   (GET "/form_instances" {:keys [email instance-id alias params] :as req}
     (let [{:keys [survey-id
                   form-id
                   page-size
-                  cursor]} (spec/validate-params params-spec
-                                                 (rename-keys params
-                                                              {:survey_id :survey-id
-                                                               :form_id :form-id
-                                                               :page_size :page-size}))
+                  cursor
+                  submission-date]} (spec/validate-params params-spec
+                                                          (rename-keys params
+                                                                       {:survey_id :survey-id
+                                                                        :form_id :form-id
+                                                                        :page_size :page-size
+                                                                        :submission_date :submission-date}))
           page-size (when page-size
                       (Long/parseLong page-size))
           user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)
-          form (find-form (:forms survey) form-id)]
+          form (find-form (:forms survey) form-id)
+          parsed-date (parse-filter submission-date)]
       (if (some? form)
         (-> remote-api
             (form-instance/list instance-id user-id form {:page-size page-size
-                                                          :cursor cursor})
+                                                          :cursor cursor
+                                                          :submission-date (:timestamp parsed-date)
+                                                          :operator (:operator parsed-date)})
             (add-next-page-url (utils/get-api-root req) alias survey-id form-id page-size)
             (response))
         {:status 404

--- a/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/form_instance.clj
@@ -61,7 +61,7 @@
   (let [parsed (parse-filter s)]
     (boolean (and (:operator parsed) (:timestamp parsed)))))
 
-(s/def ::submission-date valid-filter?)
+(s/def ::submission-date (s/nilable valid-filter?))
 
 (def params-spec (s/keys :req-un [::spec/survey-id ::spec/form-id]
                          :opt-un [::spec/cursor ::spec/page-size
@@ -84,7 +84,8 @@
           user-id (user/id-by-email-or-throw-error remote-api instance-id email)
           survey (survey/by-id remote-api instance-id user-id survey-id)
           form (find-form (:forms survey) form-id)
-          parsed-date (parse-filter submission-date)]
+          parsed-date (when submission-date
+                        (parse-filter submission-date))]
       (if (some? form)
         (-> remote-api
             (form-instance/list instance-id user-id form {:page-size page-size

--- a/api/test/clojure/org/akvo/flow_api/end_to_end.clj
+++ b/api/test/clojure/org/akvo/flow_api/end_to_end.clj
@@ -50,3 +50,15 @@
                      {:as :json
                       :headers {"huge" (apply str (repeat 30000 "x"))}
                       :content-type :json}))))))
+
+(deftest form-instances
+  (testing "Submission date filter is optional"
+    (let [response (clj-http.client/get "http://mainnetwork:3000/orgs/akvoflowsandbox/form_instances"
+                     {:as :json
+                      :headers {"x-akvo-email" "akvo.flow.user.test@gmail.com"}
+                      :query-params {:survey_id "152342023"
+                                     :form_id "146532016"
+                                     :page_size 2}
+                      :content-type :json})]
+      (is (= 200 (:status response)))
+      (is (= 2 (-> response :body :formInstances count))))))

--- a/api/test/clojure/org/akvo/flow_api/endpoint/form_instance_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/endpoint/form_instance_test.clj
@@ -1,0 +1,18 @@
+(ns org.akvo.flow-api.endpoint.form-instance-test
+  (:require [clojure.test :refer [deftest testing are]]
+            [org.akvo.flow-api.endpoint.form-instance :refer :all])
+  (:import java.time.Instant))
+
+
+(deftest filtering-by-submission-date
+  (testing "Parsing submissionDate expression"
+    (let [ts (Instant/parse "2019-11-11T14:02:48Z")]
+      (are [x y] (= y (parse-filter x))
+        ">1573480968" {:operator ">" :timestamp ts}
+        ">=1573480968" {:operator ">=" :timestamp ts}
+        "<=1573480968" {:operator "<=" :timestamp ts}
+        "<1573480968" {:operator "<" :timestamp ts}
+        ">=2019-11-11T14:02:48Z" {:operator ">=" :timestamp ts}
+        ">2019-11-11T14:02:48Z" {:operator ">" :timestamp ts}
+        "<=2019-11-11T14:02:48Z" {:operator "<=" :timestamp ts}
+        "<2019-11-11T14:02:48Z" {:operator "<" :timestamp ts}))))


### PR DESCRIPTION
* Allow a user of the API to filter by submission date
* The value of the query parameter is a inequality expression, e.g.
  `submission_date=%3E%3D1573480968`
* Since the expression can contain the `=` string, it *must* be
  URLEncoded