### PR TITLE
[#195] Use /userinfo endpoint when email is not present in JWT

### DIFF
--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -93,26 +93,7 @@ http {
           local cjson = require("cjson")
           local openidc = require("resty.openidc")
 
-          local function cache_set(type, key, value, exp)
-              local dict = ngx.shared[type]
-              if dict and (exp > 0) then
-                local success, err, forcible = dict:set(key, value, exp)
-                ngx.log(ngx.DEBUG, "cache set: success=", success, " err=", err, " forcible=", forcible)
-              end
-          end
-
-            -- retrieve value from server-wide cache if available
-          local function cache_get(type, key)
-              local dict = ngx.shared[type]
-              local value
-              if dict then
-                value = dict:get(key)
-                if value then ngx.log(ngx.DEBUG, "cache hit: type=", type, " key=", key) end
-              end
-              return value
-          end
-
-          function is_empty (s)
+          local function is_empty (s)
             return string.len(string.gsub(s, "%s+", "")) == 0
           end
 
@@ -143,7 +124,6 @@ http {
 
          local opts = {
             discovery = os.getenv("OIDC_DISCOVERY_URL"),
-
             token_signing_alg_values_expected = { "RS256" },
             accept_none_alg = false,
             accept_unsupported_alg = false,
@@ -176,11 +156,21 @@ http {
            ngx.log(ngx.DEBUG, "bearer_jwt_verify response: mail ", res.email)
            ngx.req.set_header("X-Akvo-Email", res.email)
          else
-           local error = cjson.encode({error="No available email in jwt"})
-           ngx.say(error)
-           ngx.exit(ngx.HTTP_FORBIDDEN)
+	   -- Email not available in JWT, calling userinfo
+	   local res, err = openidc.call_userinfo_endpoint(opts, access_token)
+	   if err or not res then
+	     ngx.status = 403
+	     if err then
+	       ngx.say(cjson.encode({error=err}))
+	     else
+	       ngx.say(cjson.encode({error="Invalid access_token"}))
+	     end
+	     ngx.exit(ngx.HTTP_FORBIDDEN)
+	   else
+	     ngx.log(ngx.DEBUG, "UserInfo response: email ", res.email)
+	     ngx.req.set_header("X-Akvo-Email", res.email)
+	   end
 	 end
-
       }
 
       rewrite ^/flow(/.*)$ $1 break;


### PR DESCRIPTION
* A token produced by the browser authentication flow contains by
  default the `email` claim. In the case of a token produced by
  `grant_type=password` and a "public" client, the JWT does not
  contain the `email` claim.
* To support Flow API users we we need to fallback and use the
  `/userinfo` endpoint and get the email for a given token
* The initial token request *must* use the scopes `openid` and
  `email`