### PR TITLE
[#195] id_token of Auth0 contains email claim

### DIFF
--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -156,20 +156,8 @@ http {
            ngx.log(ngx.DEBUG, "bearer_jwt_verify response: mail ", res.email)
            ngx.req.set_header("X-Akvo-Email", res.email)
          else
-	   -- Email not available in JWT, calling userinfo
-	   local res, err = openidc.call_userinfo_endpoint(opts, access_token)
-	   if err or not res then
-	     ngx.status = 403
-	     if err then
-	       ngx.say(cjson.encode({error=err}))
-	     else
-	       ngx.say(cjson.encode({error="Invalid access_token"}))
-	     end
-	     ngx.exit(ngx.HTTP_FORBIDDEN)
-	   else
-	     ngx.log(ngx.DEBUG, "UserInfo response: email ", res.email)
-	     ngx.req.set_header("X-Akvo-Email", res.email)
-	   end
+           ngx.say(cjson.encode({error="Invalid access_token"}))
+           ngx.exit(ngx.HTTP_FORBIDDEN)
 	 end
       }
 


### PR DESCRIPTION
We need to use the `id_token` of the reponse from Auth0. When used
the in combination with `scope=openid email` the token already
contains the email claim, required by us.