### PR TITLE
[#200] Respond HTTP 204 when no more changes are available

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
@@ -43,7 +43,7 @@
             (if (unilog/valid-offset? offset db-spec)
               (if (= offset (unilog/get-cursor db-spec)) ;; end of the log
                 (-> (status {} 204)
-                    (header "Cache-Control" "max-age=3600"))
+                    (header "Cache-Control" "max-age=60"))
                 (let [changes (->
                                (unilog/process-unilog-events offset db-spec instance-id (:remote-api deps))
                                (select-keys [:form-instance-changed

--- a/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
@@ -32,7 +32,7 @@
   [req]
   (let [alias (:alias req)
         api-root (utils/get-api-root req)
-        db {:connection (:unilog-db-connection req)}
+        db (:unilog-db-connection req)
         cursor (unilog/get-cursor db)]
     (response {:next-sync-url (next-sync-url api-root alias cursor)})))
 
@@ -64,7 +64,7 @@
       (if (= "true" initial)
         (initial-response req)
         (if (and next cursor)
-          (let [db {:connection (:unilog-db-connection req)}
+          (let [db (:unilog-db-connection req)
                 offset (Long/parseLong cursor)]
             (if (unilog/valid-offset? offset db)
               (if (= offset (unilog/get-cursor db)) ;; end of the log

--- a/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/sync.clj
@@ -28,7 +28,6 @@
 
 (def no-more-changes (-> (status {} 204) (header "Cache-Control" "max-age=60")))
 
-
 (defn initial-response
   [req]
   (let [alias (:alias req)

--- a/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
+++ b/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
@@ -148,7 +148,6 @@
           data-point-changed (doall (data-point/by-ids ds (:data-point-changed events-2)))]
       (assoc events-2 :form-instance-changed form-instances :data-point-changed data-point-changed))))
 
-
 (defn get-db-name [instance-id]
   (str "u_" instance-id))
 

--- a/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
+++ b/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
@@ -155,5 +155,5 @@
   (fn [request]
     (let [db-name (get-db-name (:instance-id request))
           db-spec (-> unilog-db :spec (assoc :db-name db-name) event-log-spec)]
-      (with-open [connection (jdbc/get-connection  db-spec)]
-        (handler (assoc request :unilog-db-connection connection))))))
+      (jdbc/with-db-connection [conn db-spec]
+        (handler (assoc request :unilog-db-connection conn))))))

--- a/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
+++ b/api/src/clojure/org/akvo/flow_api/unilog/unilog.clj
@@ -117,22 +117,22 @@
    :data-point-changed data-point-changed
    :data-point-deleted data-point-deleted})
 
-(defn get-cursor [config]
-  (let [result (first (jdbc/query (event-log-spec config)
+(defn get-cursor [db]
+  (let [result (first (jdbc/query db
                                   ["SELECT MAX(id) AS cursor FROM event_log"]))]
     (or (:cursor result) 0)))
 
-(defn valid-offset? [offset config]
+(defn valid-offset? [offset db]
   (or (= offset 0)
-      (let [result (first (jdbc/query (event-log-spec config)
+      (let [result (first (jdbc/query db
                                       ["SELECT id AS offset FROM event_log WHERE id = ?" offset]))]
         (boolean (:offset result)))))
 
-(defn process-unilog-events [offset config instance-id remote-api]
+(defn process-unilog-events [offset db instance-id remote-api]
   (ds/with-remote-api remote-api instance-id
     (let [ds (DatastoreServiceFactory/getDatastoreService)
           events (process-new-events
-                   (jdbc/reducible-query (event-log-spec config)
+                   (jdbc/reducible-query db
                                          ["SELECT id, payload::text AS payload FROM event_log WHERE id > ? ORDER BY id ASC LIMIT 300" offset]
                                          {:auto-commit? false :fetch-size 300}))
           form-id->form (reduce (fn [acc form-id]
@@ -147,3 +147,14 @@
                              (:form-instances-to-load events-2)))
           data-point-changed (doall (data-point/by-ids ds (:data-point-changed events-2)))]
       (assoc events-2 :form-instance-changed form-instances :data-point-changed data-point-changed))))
+
+
+(defn get-db-name [instance-id]
+  (str "u_" instance-id))
+
+(defn wrap-db-connection [handler unilog-db]
+  (fn [request]
+    (let [db-name (get-db-name (:instance-id request))
+          db-spec (-> unilog-db :spec (assoc :db-name db-name) event-log-spec)]
+      (with-open [connection (jdbc/get-connection  db-spec)]
+        (handler (assoc request :unilog-db-connection connection))))))

--- a/api/test/clojure/org/akvo/flow_api/sync_end_to_end.clj
+++ b/api/test/clojure/org/akvo/flow_api/sync_end_to_end.clj
@@ -123,4 +123,4 @@
                                                                 "content-type" "application/json"
                                                                 "accept" "application/vnd.akvo.flow.v2+json"}})]
               (is (= 204 status))
-              (is (= "max-age=3600" (get headers "Cache-Control"))))))))))
+              (is (= "max-age=60" (get headers "Cache-Control"))))))))))

--- a/api/test/clojure/org/akvo/flow_api/sync_end_to_end.clj
+++ b/api/test/clojure/org/akvo/flow_api/sync_end_to_end.clj
@@ -25,7 +25,7 @@
                           "content-type" "application/json"
                           "accept" "application/vnd.akvo.flow.v2+json"}
                 :query-params params})
-     [:status :body])
+     [:status :body :headers])
     (catch clojure.lang.ExceptionInfo e
       (select-keys (ex-data e) [:status :body]))))
 
@@ -116,4 +116,11 @@
                    (set (map :id (:formInstanceChanged changes)))))
             (is (= #{"144622023"}
                    (set (map :id (:dataPointChanged changes)))))
-            (is (= (:dataPointDeleted changes) ["144602051"]))))))))
+            (is (= (:dataPointDeleted changes) ["144602051"]))
+            (let [{:keys [headers status]} (http/get nextSyncUrl
+                                                     {:as :json
+                                                      :headers {"x-akvo-email" user
+                                                                "content-type" "application/json"
+                                                                "accept" "application/vnd.akvo.flow.v2+json"}})]
+              (is (= 204 status))
+              (is (= "max-age=3600" (get headers "Cache-Control"))))))))))

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -49,6 +49,18 @@ docker run \
        --entrypoint /usr/local/openresty/bin/openresty \
        "akvo/flow-api-auth0-proxy" -t -c /usr/local/openresty/nginx/conf/nginx.conf
 
+# Checking nginx caching
+(
+    cd nginx-auth0
+    docker-compose up -d
+    sleep 5
+    ./test.sh "http://localhost:8082/flow/ok" 2>&1 | grep 'X-Cache-Status: MISS'
+    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: MISS'
+    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
+    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
+    docker-compose down -v
+)
+
 # Backend tests
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml up --build -d
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml run --no-deps tests dev/run-as-user.sh lein do clean, check, eastwood, test :all

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -49,19 +49,6 @@ docker run \
        --entrypoint /usr/local/openresty/bin/openresty \
        "akvo/flow-api-auth0-proxy" -t -c /usr/local/openresty/nginx/conf/nginx.conf
 
-# Checking nginx caching
-(
-    cd nginx-auth0
-    docker-compose up -d
-    sleep 5
-    ./test.sh "http://localhost:8082/flow/ok" 2>&1 | grep 'X-Cache-Status: MISS'
-    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: MISS'
-    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
-    ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
-    ./test.sh "http://localhost:8082/flow/" --header "Pragma: no-cache" 2>&1 | grep 'X-Cache-Status: BYPASS'
-    docker-compose down -v
-)
-
 # Backend tests
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml up --build -d
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml run --no-deps tests dev/run-as-user.sh lein do clean, check, eastwood, test :all

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -58,6 +58,7 @@ docker run \
     ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: MISS'
     ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
     ./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
+    ./test.sh "http://localhost:8082/flow/" --header "Pragma: no-cache" 2>&1 | grep 'X-Cache-Status: BYPASS'
     docker-compose down -v
 )
 

--- a/nginx-auth0/Dockerfile
+++ b/nginx-auth0/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:1.13.6.2-2-alpine-fat
 
-RUN apk add --no-cache build-base openssl-dev git
+RUN apk add --no-cache build-base openssl-dev git && mkdir -p /data/nginx/cache
 
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-openidc 1.7.2-1
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-jwt 0.2.0-0

--- a/nginx-auth0/docker-compose.yml
+++ b/nginx-auth0/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - OIDC_DISCOVERY_URL=https://akvotest.eu.auth0.com/.well-known/openid-configuration
       - OIDC_EXPECTED_ISSUER=https://akvotest.eu.auth0.com/
   upstream:
-    image: jmalloc/echo-server:latest
+    image: openresty/openresty:1.13.6.2-2-alpine-fat
     network_mode: service:mainnetwork
-    environment:
-      - PORT=3000
+    entrypoint: ["/usr/local/openresty/bin/openresty", "-c", "/usr/local/src/nginx-test.conf", "-g", "daemon off;"]
+    volumes:
+      - ./:/usr/local/src:ro

--- a/nginx-auth0/docker-compose.yml
+++ b/nginx-auth0/docker-compose.yml
@@ -1,21 +1,21 @@
 version: "3"
 
 services:
-  mainnetwork:
+  secondnetwork:
     image: alpine:3.10
     command: tail -f /dev/null
     ports:
       - 8082:8082
   nginx-auth0:
     image: akvo/flow-api-auth0-proxy:latest
-    network_mode: service:mainnetwork
+    network_mode: service:secondnetwork
     environment:
       - FLOW_API_BACKEND_URL=http://localhost:3000
       - OIDC_DISCOVERY_URL=https://akvotest.eu.auth0.com/.well-known/openid-configuration
       - OIDC_EXPECTED_ISSUER=https://akvotest.eu.auth0.com/
   upstream:
     image: akvo/flow-api-auth0-proxy:latest
-    network_mode: service:mainnetwork
+    network_mode: service:secondnetwork
     entrypoint: ["/usr/local/openresty/bin/openresty", "-c", "/usr/local/src/nginx-test.conf", "-g", "daemon off;"]
     volumes:
       - ./:/usr/local/src:ro

--- a/nginx-auth0/docker-compose.yml
+++ b/nginx-auth0/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - OIDC_DISCOVERY_URL=https://akvotest.eu.auth0.com/.well-known/openid-configuration
       - OIDC_EXPECTED_ISSUER=https://akvotest.eu.auth0.com/
   upstream:
-    image: openresty/openresty:1.13.6.2-2-alpine-fat
+    image: akvo/flow-api-auth0-proxy:latest
     network_mode: service:mainnetwork
     entrypoint: ["/usr/local/openresty/bin/openresty", "-c", "/usr/local/src/nginx-test.conf", "-g", "daemon off;"]
     volumes:

--- a/nginx-auth0/nginx-test.conf
+++ b/nginx-auth0/nginx-test.conf
@@ -16,10 +16,12 @@ http {
 
     location / {
       return 204;
+      add_header Cache-Control max-age=120;
     }
 
     location /ok {
       return 200 '{}';
+      add_header Cache-Control no-cache;
     }
   }
 }

--- a/nginx-auth0/nginx-test.conf
+++ b/nginx-auth0/nginx-test.conf
@@ -8,20 +8,17 @@ events {
 http {
 
   server_tokens off;
-  lua_package_path '~/lua/?.lua;;';
 
   server {
 
     listen 3000;
+    default_type application/json;
 
     location / {
-      default_type application/json;
-      add_header Cache-Control max-age=3600;
       return 204;
     }
 
     location /ok {
-      default_type application/json;
       return 200 '{}';
     }
   }

--- a/nginx-auth0/nginx-test.conf
+++ b/nginx-auth0/nginx-test.conf
@@ -1,0 +1,28 @@
+worker_processes 1;
+error_log logs/error.log;
+
+events {
+  worker_connections 128;
+}
+
+http {
+
+  server_tokens off;
+  lua_package_path '~/lua/?.lua;;';
+
+  server {
+
+    listen 3000;
+
+    location / {
+      default_type application/json;
+      add_header Cache-Control max-age=3600;
+      return 204;
+    }
+
+    location /ok {
+      default_type application/json;
+      return 200 '{}';
+    }
+  }
+}

--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -174,6 +174,8 @@ http {
       proxy_cache_methods GET;
       proxy_cache_key $proxy_host$request_uri$akvoemail;
       proxy_cache_bypass $http_pragma;
+      proxy_cache_lock_timeout 30s;
+      proxy_cache_lock_age 30s;
 
       add_header X-Cache-Status $upstream_cache_status;
 

--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -173,7 +173,6 @@ http {
       proxy_cache_lock on;
       proxy_cache_methods GET;
       proxy_cache_key $proxy_host$request_uri$akvoemail;
-      proxy_cache_bypass $http_pragma;
       proxy_cache_lock_timeout 30s;
       proxy_cache_lock_age 30s;
 

--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -173,7 +173,6 @@ http {
       proxy_cache_lock on;
       proxy_cache_methods GET;
       proxy_cache_key $proxy_host$request_uri$akvoemail;
-      proxy_cache_valid 204 60m;
       proxy_cache_bypass $http_pragma;
 
       add_header X-Cache-Status $upstream_cache_status;

--- a/nginx-auth0/nginx.conf
+++ b/nginx-auth0/nginx.conf
@@ -34,6 +34,9 @@ http {
   lua_shared_dict userinfo 20m;
   lua_capture_error_log 32m;
 
+  # Cache 204 responses
+  proxy_cache_path /data/nginx/cache levels=1:2 keys_zone=http_204:5m max_size=1g inactive=60m use_temp_path=off;
+
   init_by_lua_block {
         local errlog = require "ngx.errlog"
         local status, err = errlog.set_filter_level(ngx.WARN)
@@ -87,6 +90,8 @@ http {
       set_by_lua $upstream 'return os.getenv("FLOW_API_BACKEND_URL")';
       lua_ssl_verify_depth 2;
       lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.pem;
+
+      set $akvoemail "";
 
       access_by_lua_block {
 
@@ -155,11 +160,23 @@ http {
          if res.email then
            ngx.log(ngx.DEBUG, "bearer_jwt_verify response: mail ", res.email)
            ngx.req.set_header("X-Akvo-Email", res.email)
+           ngx.var.akvoemail = res.email
          else
            ngx.say(cjson.encode({error="Invalid access_token"}))
            ngx.exit(ngx.HTTP_FORBIDDEN)
 	 end
       }
+
+      proxy_cache http_204;
+      proxy_cache_revalidate off;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_methods GET;
+      proxy_cache_key $proxy_host$request_uri$akvoemail;
+      proxy_cache_valid 204 60m;
+      proxy_cache_bypass $http_pragma;
+
+      add_header X-Cache-Status $upstream_cache_status;
 
       rewrite ^/flow(/.*)$ $1 break;
       proxy_pass http://localhost:3000;

--- a/nginx-auth0/test-cache.sh
+++ b/nginx-auth0/test-cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Checking nginx caching
+
+docker-compose up -d
+
+./test.sh "http://localhost:8082/flow/ok" 2>&1 | grep 'X-Cache-Status: MISS'
+./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: MISS'
+./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
+./test.sh "http://localhost:8082/flow/" 2>&1 | grep 'X-Cache-Status: HIT'
+
+docker-compose down -v

--- a/nginx-auth0/test.sh
+++ b/nginx-auth0/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+token=$(curl --silent \
+	     --data "client_id=qsxNP3Nex0wncADQ9Re6Acz6Fa55SuU8" \
+	     --data "username=${AUTH0_USER}" \
+	     --data "password=${AUTH0_PASSWORD}" \
+	     --data "grant_type=password" \
+	     --data "scope=openid email" \
+	     --url "https://akvotest.eu.auth0.com/oauth/token" \
+	    | jq -M -r .id_token)
+
+URL="${1}"
+shift
+
+curl --verbose \
+     --header "Content-Type: application/json" \
+     --header "Accept: application/vnd.akvo.flow.v2+json" \
+     --header "Authorization: Bearer ${token}" \
+     --request GET \
+     "$@" \
+     --url "${URL}" | jq -M

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,6 +54,10 @@ http {
       proxy_set_header Host $host;
     }
 
+    location ~ ^/flow/orgs/.*/sync.* {
+      return 400 '{"message": "Please use the new authentication method"}';
+    }
+
     location /flow {
 
       default_type application/json;


### PR DESCRIPTION
The proxy server (nginx) will cache this response for 1h. Useful for _eager_ clients re-requesting the same thing over and over again. The value of 1h is arbitrary and we can adjust it.

A client can bypass the proxy by using a request header `Pragma: no-cache`