### PR TITLE
[#212] Report HTTP 502 when GAE reports HTTP 500

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/anomaly.clj
@@ -17,3 +17,6 @@
 
 (defn too-many-requests [message m]
   (throw-anomaly ::too-many-requests message m))
+
+(defn bad-gateway [message m]
+  (throw-anomaly ::bad-gateway message m))

--- a/api/src/clojure/org/akvo/flow_api/endpoint/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/endpoint/anomaly.clj
@@ -32,3 +32,8 @@
   (-> (body e)
       (response)
       (assoc :status 429)))
+
+(defmethod handle :org.akvo.flow-api.anomaly/bad-gateway [e]
+  (-> (body e)
+      (response)
+      (assoc :status 502)))

--- a/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
@@ -18,4 +18,6 @@
         (if (or (.contains (.getMessage e) "Over Quota")
                 (.contains (.getMessage e) "required more quota"))
           (an/too-many-requests "This application is temporarily over its serving quota." {})
-          (throw e))))))
+          (if (.contains (.getMessage e) "Please try again in 30 seconds")
+            (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
+            (throw e)))))))


### PR DESCRIPTION
The "upstream" server (dependency) is not able to serve the request.
Although our HTTP endpoint is not strictly a _proxy_, is more or less
acting like one.