### PR TITLE
NPE when handling exceptions

### DIFF
--- a/api/src/clojure/org/akvo/flow_api/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/anomaly.clj
@@ -15,8 +15,8 @@
 (defn bad-request [message m]
   (throw-anomaly ::bad-request message m))
 
-(defn too-many-requests [message m]
-  (throw-anomaly ::too-many-requests message m))
+(defn too-many-requests []
+  (throw-anomaly ::too-many-requests "This application is temporarily over its serving quota." {}))
 
-(defn bad-gateway [message m]
-  (throw-anomaly ::bad-gateway message m))
+(defn bad-gateway []
+  (throw-anomaly ::bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {}))

--- a/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
@@ -12,9 +12,9 @@
 
 (defn translate-exception [e]
   (condp #(.contains %2 %1) (or (.getMessage e) "")
-    "Over Quota" (an/too-many-requests "This application is temporarily over its serving quota." {})
-    "required more quota" (an/too-many-requests "This application is temporarily over its serving quota." {})
-    "Please try again in 30 seconds" (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
+    "Over Quota" (an/too-many-requests)
+    "required more quota" (an/too-many-requests)
+    "Please try again in 30 seconds" (an/bad-gateway)
     (throw e)))
 
 (defn wrap-log-errors [handler]

--- a/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
@@ -11,14 +11,11 @@
         (anomaly/handle e)))))
 
 (defn translate-exception [e]
-  (if-not (.getMessage e)
-    (throw e)
-    (if (or (.contains (.getMessage e) "Over Quota")
-          (.contains (.getMessage e) "required more quota"))
-      (an/too-many-requests "This application is temporarily over its serving quota." {})
-      (if (.contains (.getMessage e) "Please try again in 30 seconds")
-        (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
-        (throw e)))))
+  (condp #(.contains %2 %1) (or (.getMessage e) "")
+    "Over Quota" (an/too-many-requests "This application is temporarily over its serving quota." {})
+    "required more quota" (an/too-many-requests "This application is temporarily over its serving quota." {})
+    "Please try again in 30 seconds" (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
+    (throw e)))
 
 (defn wrap-log-errors [handler]
   (fn [request]

--- a/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
@@ -10,14 +10,17 @@
       (catch ExceptionInfo e
         (anomaly/handle e)))))
 
+(defn translate-exception [e]
+  (if (or (.contains (.getMessage e) "Over Quota")
+        (.contains (.getMessage e) "required more quota"))
+    (an/too-many-requests "This application is temporarily over its serving quota." {})
+    (if (.contains (.getMessage e) "Please try again in 30 seconds")
+      (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
+      (throw e))))
+
 (defn wrap-log-errors [handler]
   (fn [request]
     (try
       (handler request)
       (catch Throwable e
-        (if (or (.contains (.getMessage e) "Over Quota")
-                (.contains (.getMessage e) "required more quota"))
-          (an/too-many-requests "This application is temporarily over its serving quota." {})
-          (if (.contains (.getMessage e) "Please try again in 30 seconds")
-            (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
-            (throw e)))))))
+        (translate-exception e)))))

--- a/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
+++ b/api/src/clojure/org/akvo/flow_api/middleware/anomaly.clj
@@ -11,12 +11,14 @@
         (anomaly/handle e)))))
 
 (defn translate-exception [e]
-  (if (or (.contains (.getMessage e) "Over Quota")
-        (.contains (.getMessage e) "required more quota"))
-    (an/too-many-requests "This application is temporarily over its serving quota." {})
-    (if (.contains (.getMessage e) "Please try again in 30 seconds")
-      (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
-      (throw e))))
+  (if-not (.getMessage e)
+    (throw e)
+    (if (or (.contains (.getMessage e) "Over Quota")
+          (.contains (.getMessage e) "required more quota"))
+      (an/too-many-requests "This application is temporarily over its serving quota." {})
+      (if (.contains (.getMessage e) "Please try again in 30 seconds")
+        (an/bad-gateway "The server encountered an error and could not complete your request. Please try again in 30 seconds." {})
+        (throw e)))))
 
 (defn wrap-log-errors [handler]
   (fn [request]

--- a/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
@@ -1,0 +1,22 @@
+(ns org.akvo.flow-api.middleware.anomaly-test
+  (:require [clojure.test :refer :all]
+            [org.akvo.flow-api.middleware.anomaly :as anomaly])
+  (:import (java.io IOException)))
+
+(defn ex? [exception-or-message]
+  (try
+    (anomaly/translate-exception (if (= (type exception-or-message) String)
+                                   (IOException. exception-or-message)
+                                   exception-or-message))
+    (is false "Should never reach here")
+    (catch Exception e
+      (if (ex-data e)
+        (:org.akvo.flow-api/anomaly (ex-data e))
+        e))))
+
+(deftest exception-translation
+  (let [exception (ArrayIndexOutOfBoundsException. "Hi I am not special")]
+    (is (= exception (ex? exception))))
+  (is (= (ex? "... Over Quota ...") :org.akvo.flow-api.anomaly/too-many-requests))
+  (is (= (ex? "... required more quota ...") :org.akvo.flow-api.anomaly/too-many-requests))
+  (is (= (ex? "... Please try again in 30 seconds ...") :org.akvo.flow-api.anomaly/bad-gateway)))

--- a/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
@@ -6,9 +6,9 @@
 (defn ex? [exception-or-message]
   (try
     (anomaly/translate-exception (if (= (type exception-or-message) String)
-                                   (IOException. exception-or-message)
+                                   (IOException. ^String exception-or-message)
                                    exception-or-message))
-    (is false "Should never reach here")
+    "Should never reach here"
     (catch Exception e
       (if (ex-data e)
         (:org.akvo.flow-api/anomaly (ex-data e))

--- a/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
+++ b/api/test/clojure/org/akvo/flow_api/middleware/anomaly_test.clj
@@ -17,6 +17,8 @@
 (deftest exception-translation
   (let [exception (ArrayIndexOutOfBoundsException. "Hi I am not special")]
     (is (= exception (ex? exception))))
+  (let [exception (ArrayIndexOutOfBoundsException. nil)]
+    (is (= exception (ex? exception))))
   (is (= (ex? "... Over Quota ...") :org.akvo.flow-api.anomaly/too-many-requests))
   (is (= (ex? "... required more quota ...") :org.akvo.flow-api.anomaly/too-many-requests))
   (is (= (ex? "... Please try again in 30 seconds ...") :org.akvo.flow-api.anomaly/bad-gateway)))


### PR DESCRIPTION
There is some exception that has no message and that is causing the error handling to throw a NPE exception itself.

Once we fix this issue we can find out what is the actual cause of the user error.

Fixes #214