### PR TITLE
ci: Force use of gke-gcloud-auth-plugin for kubectl

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,6 +29,7 @@ blocks:
               else
                 export TRAVIS_PULL_REQUEST="false"
               fi
+            - export USE_GKE_GCLOUD_AUTH_PLUGIN=True
             - ./ci/build.sh && ./ci/deploy.sh
       env_vars:
         - name: CLOUDSDK_CORE_DISABLE_PROMPTS


### PR DESCRIPTION
Without it, authentication fails

> error: The gcp auth plugin has been removed.
> Please use the "gke-gcloud-auth-plugin" kubectl/client-go credential plugin instead.
> See https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke for further details