### PR TITLE
[#255] Use jetty-logging.properties for Jetty log config

### DIFF
--- a/api/resources/jetty-logging.properties
+++ b/api/resources/jetty-logging.properties
@@ -1,0 +1,15 @@
+# https://www.eclipse.org/jetty/documentation/jetty-9/index.html#configuring-jetty-logging
+
+## Force jetty logging implementation
+#org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+
+## Set logging levels from: ALL, DEBUG, INFO, WARN, OFF
+org.eclipse.jetty.LEVEL=INFO
+#com.example.LEVEL=INFO
+
+## Hide stacks traces in logs?
+#com.example.STACKS=false
+
+## Show the source file of a log location?
+#com.example.SOURCE=false
+


### PR DESCRIPTION
The documentation https://www.eclipse.org/jetty/documentation/jetty-9/index.html#configuring-jetty-logging
 states it should work this way.
We are currently seeing DEBUG logs in production, which should be happening.

I haven't been able to test this locally as there's no documentation on how to setup a functional development environment besides running `docker-compose up`. It doesn't add code, so hopefully it's safe.

Closes #255 