### PR TITLE
[#259] Upgrade openidc to stop using string.buffer

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -76,8 +76,11 @@ docker run \
 	   cljkondo/clj-kondo:2022.10.14-alpine \
 	   clj-kondo --lint src test
 
+log Building images for Backend tests
+docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml build
 log Starting Backend tests docker environment
-docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml up --build -d
+docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml up -d
+sleep 20 # an extra sleep to wait for the compilation
 log Starting tests
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml exec -T tests dev/run-as-user.sh lein do clean, check, eastwood, eftest :all
 log Building uberjar

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -80,7 +80,6 @@ log Building images for Backend tests
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml build
 log Starting Backend tests docker environment
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml up -d
-sleep 20 # an extra sleep to wait for the compilation
 log Starting tests
 docker-compose -p akvo-flow-api-ci -f docker-compose.yml -f docker-compose.ci.yml exec -T tests dev/run-as-user.sh lein do clean, check, eastwood, eftest :all
 log Building uberjar

--- a/nginx-auth0/Dockerfile
+++ b/nginx-auth0/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache \
     build-base~=0.5 \
     openssl-dev~=1 \
     git~=2 && \
-    luarocks install lua-resty-openidc 1.7.2-1 && \
+    luarocks install lua-resty-openidc 1.7.6-3 && \
     cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.pem && \
     mkdir -p /data/nginx/cache
 


### PR DESCRIPTION
string.buffer can't be imported anymore. Just doesn't exist in the docker containers anymore. It should be in [LUAJit] but for some reason that isn't the case anymore. The newer version of openidc doesn't depend on string.buffer

Fix #259

[LUAJit]: https://luapower.com/files/luapower/csrc/luajit/src/doc/ext_buffer.html

------------

Another bug popped up in the CI and instead of creating a new branch, I fixed it in this one. See commit https://github.com/akvo/akvo-flow-api/pull/260/commits/4947a358cbc18af5b467b5889a5327d83a56e849